### PR TITLE
Adding support for connection strings, and switching to using the pool for query.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,33 +1,39 @@
 const pg = require('pg');
 const co = require('co');
 
-module.exports = function (config) {
-  if (!config) {
-    throw new Error('No config supplied!');
+module.exports = function (config, defaults) {
+  if (typeof config == "object") {
+    config = {
+      user: config.user || process.env.BOTKIT_STORAGE_POSTGRES_USER || 'botkit',
+      database: config.database || process.env.BOTKIT_STORAGE_POSTGRES_DATABASE || 'botkit',
+      password: config.password || process.env.BOTKIT_STORAGE_POSTGRES_PASSWORD || 'botkit',
+      host: config.host || process.env.BOTKIT_STORAGE_POSTGRES_HOST || 'localhost',
+      port: config.port || process.env.BOTKIT_STORAGE_POSTGRES_PORT || '5432',
+      max: config.maxClients || process.env.BOTKIT_STORAGE_POSTGRES_MAX_CLIENTS || '10',
+      idleTimeoutMillis: config.idleTimeoutMillis || process.env.BOTKIT_STORAGE_POSTGRES_IDLE_TIMEOUT_MILLIS || '30000',
+    };
+  } else if (typeof config == 'string') {
+    //nothing to validate, other than it being a string
+  } else {
+    throw new Error('Can only accept a connection string, or a configuration object');
   }
 
-  config = {
-    user: config.user || process.env.BOTKIT_STORAGE_POSTGRES_USER || 'botkit',
-    database: config.database || process.env.BOTKIT_STORAGE_POSTGRES_DATABASE || 'botkit',
-    password: config.password || process.env.BOTKIT_STORAGE_POSTGRES_PASSWORD || 'botkit',
-    host: config.host || process.env.BOTKIT_STORAGE_POSTGRES_HOST || 'localhost',
-    port: config.port || process.env.BOTKIT_STORAGE_POSTGRES_PORT || '5432',
-    max: config.maxClients || process.env.BOTKIT_STORAGE_POSTGRES_MAX_CLIENTS || '10',
-    idleTimeoutMillis: config.idleTimeoutMillis || process.env.BOTKIT_STORAGE_POSTGRES_IDLE_TIMEOUT_MILLIS || '30000',
-  };
+  if (defaults) {
+    pg.defaults = Object.assign(pg.defaults, defaults);
+  }
 
   const promisedPool = co(function *() {
-    const q = (client, qstr) => new Promise((resolve,reject) => client.query(qstr, [], (err, res) => err ? reject(err) : resolve(res)))
+    const q = (client, qstr) => new Promise((acc, rej) => client.query(qstr, [], (err, res) => err ? rej(err) : acc(res)))
       .catch(err => {throw new Error(`Could not execute '${qstr}'. Error: ${err.stack || err}`)});
-    const connect = (client) => new Promise((resolve,reject) => client.connect((err, done) => err ? reject(err) : resolve()))
+    const connect = (client) => new Promise((acc, rej) => client.connect((err, done) => err ? rej(err) : acc()));
 
-    const noDbClient = new pg.Client(Object.assign({}, config, {database: 'template1'}));
+    const noDbClient = new pg.Client(config);
     yield connect(noDbClient);
-    const dbexistsQuery = yield q(noDbClient, `SELECT 1 from pg_database WHERE datname='${config.database}'`);
+    const dbexistsQuery = yield q(noDbClient, `SELECT 1 from pg_database WHERE datname='${noDbClient.database}'`);
 
     if(dbexistsQuery.rows.length === 0) {
-      console.log('botkit-storage-postgres> creating db ' + config.database);
-      yield q(noDbClient, 'CREATE DATABASE ' + config.database);
+      console.log(`botkit-storage-postgres> creating db ${noDbClient.database}`);
+      yield q(noDbClient, `CREATE DATABASE ${noDbClient.database}`);
     }
 
     noDbClient.end();
@@ -35,15 +41,17 @@ module.exports = function (config) {
     const dbClient = new pg.Client(config);
     yield connect(dbClient);
 
-    yield ['botkit_teams', 'botkit_users', 'botkit_channels'].map(tableName =>
-      q(dbClient, `CREATE TABLE IF NOT EXISTS ${tableName} (
-        id char(50) NOT NULL PRIMARY KEY,
-        json TEXT NOT NULL
-      )`))
+    yield ['botkit_teams', 'botkit_users', 'botkit_channels']
+      .map(tableName => `CREATE TABLE IF NOT EXISTS ${tableName} (id char(50) NOT NULL PRIMARY KEY, json TEXT NOT NULL)`)
+      .map(createQuery => q(dbClient, createQuery));
 
     dbClient.end();
 
-    const pool = new pg.Pool(config);
+    function FakeClient() {
+      return new pg.Client(config);
+    }
+
+    const pool = yield Promise.resolve(new pg.Pool({ Client: FakeClient }));
 
     pool.on('error', function (err, client) {
       console.error('botkit-storage-postgres> idle client error', err.message, err.stack);
@@ -52,25 +60,15 @@ module.exports = function (config) {
   });
 
   promisedPool.then(() => {
-    console.log(`botkit-storage-postgres> connected to ${config.host}:${config.port}/${config.database}`);
+    console.log(`botkit-storage-postgres> connected to database`);
   }, (err) => {
-    console.error('botkit-storage-postgres> error running setup. Error: ' + err.stack);
+    console.error(`botkit-storage-postgres> error running setup. Error: '${err.stack}`);
   });
 
-  const dbexec = co.wrap(function *(func) {
+  const dbexec = co.wrap(function* (...args) {
     const pool = yield promisedPool;
-    const {client,done} = yield new Promise((resolve,reject) => pool.connect((err, client, done) =>
-      err ? reject(err) : resolve({client,done})))
-      .catch(err => {throw new Error(`Could not execute '${qstr}'. Error: ${err.stack || err}`)});;
-
-    _pool = new pg.Pool(config);
-
-    const query = (...args) => new Promise((resolve,reject) =>
-      client.query(...args, (err, res) => err ? reject(err) : resolve(res)));
-
-    const x = yield func(query, client);
-    done();
-    return x;
+    const query = yield pool.query(...args);
+    return query;
   });
 
   const wrap = (func) => {
@@ -88,31 +86,29 @@ module.exports = function (config) {
   const persisting = (tableName) => {
     return {
       get: wrap(function *(id) {
-        const result = yield dbexec(q => q(`SELECT json from ${tableName} where id = $1`, [id]));
+        const result = yield dbexec(`SELECT json from ${tableName} where id = $1`, [id]);
         if(result.rowCount === 0) {
           throw {displayName: 'NotFound'};
         }
         return JSON.parse(result.rows[0].json);
       }),
       save: wrap(function *(data) {
-        yield dbexec(q => q(`INSERT INTO ${tableName} (id, json)
-                             VALUES ($1, $2)
-                             ON CONFLICT (id) DO UPDATE SET json = EXCLUDED.json;`, [data.id, JSON.stringify(data)]))
+        yield dbexec(`INSERT INTO ${tableName} (id, json)
+                            VALUES ($1, $2)
+                            ON CONFLICT (id) DO UPDATE SET json = EXCLUDED.json;`, [data.id, JSON.stringify(data)]);
       }),
       all: wrap(function *() {
-        const result = yield dbexec(q => q(`SELECT json from ${tableName}`))
+        const result = yield dbexec(`SELECT json from ${tableName}`);
         return result.rows.map(x => JSON.parse(x.json));
       })
     };
-  }
+  };
 
   const storage = {
     teams: persisting('botkit_teams'),
     channels: persisting('botkit_channels'),
     users: persisting('botkit_users'),
-    end: () => {
-      return promisedPool.then(x => x.end())
-    }
+    end: () => promisedPool.then(x => x.end())
   };
 
   return storage;

--- a/tests/index.js
+++ b/tests/index.js
@@ -59,6 +59,9 @@ const dbConfig = {
   host: process.env.BOTKIT_STORAGE_POSTGRES_HOST || 'localhost',
   port: process.env.BOTKIT_STORAGE_POSTGRES_PORT || '5432'
 };
+
+// const dbConfig = process.env.BOTKIT_STORAGE_POSTGRES_CONNECTIONSTRING || 'postgresql://botkit:botkit@localhost:5432/botkit_test'
+
 const pgClient = new pg.Client(dbConfig);
 pgClient.connect();
 pgClient.query(`


### PR DESCRIPTION
Changed the method to support either a config object with the connection info, or a connection string. Also extended with an additional argument to be able to set some of the pg.defaults.

Switched the dbExec to use the pool.query method, as opposed to obtaining a client off the pool, and then running a query on it.

Switched some string building to use interpolation.

Added an example connection string into the test file, which can be switched out for the config to test the connection string method.
