### PR TITLE
Use Postgres JSONB data type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ npm-debug.log*
 
 # Dependency directories
 node_modules
+
+# WebStorm / IDEA Files
+.idea
+*.iml

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/lixhq/botkit-storage-postgres#readme",
   "dependencies": {
     "co": "^4.6.0",
-    "pg": "^6.1.0"
+    "pg": "^6.1.0",
+    "pg-hstore": "^2.3.2"
   },
   "engines": {
     "node": ">=6.7"


### PR DESCRIPTION
Modern versions of Postgres support JSON data natively.

I've put this behind a config option though, to preserve compatibility for existing users (also, the only change is in the initial table creation anyway).

A more comprehensive solution would be to query the DB version (e.g. `SHOW server_version;`) and then create tables and indices with the appropriate type, but that may be over-engineering things 😉