### PR TITLE
Supports postgres connection uri

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/lixhq/botkit-storage-postgres#readme",
   "dependencies": {
     "co": "^4.6.0",
-    "pg": "^6.1.0"
+    "pg": "^6.1.0",
+    "url": "^0.11.0"
   },
   "engines": {
     "node": ">=6.7"

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,23 @@
 const pg = require('pg');
 const co = require('co');
+var url = require('url');
 
 module.exports = function (config) {
   if (!config) {
     throw new Error('No config supplied!');
+  }
+
+  if(config.postgresUri) {
+    var pg_data = url.parse(config.postgresUri,true);
+    if(['postgres:','postgresql:'].indexOf(pg_data.protocol) == -1)
+      throw new Error('Not a postgres url');
+    var auth = pg_data.auth.split(':');
+    config.user = auth[0];
+    config.password = auth[1] || '';
+    config.port = pg_data.port;
+    config.host = pg_data.hostname;
+    config.database = pg_data.pathname.slice(1);
+    Object.assign(config, pg_data.query);
   }
 
   config = {

--- a/tests/index.js
+++ b/tests/index.js
@@ -53,12 +53,14 @@ var testStorageMethod = function(storageMethod, cb) {
 };
 
 const dbConfig = {
-  user: process.env.BOTKIT_STORAGE_POSTGRES_USER || 'botkit',
-  database: process.env.BOTKIT_STORAGE_POSTGRES_DATABASE || 'botkit_test',
-  password: process.env.BOTKIT_STORAGE_POSTGRES_PASSWORD || 'botkit',
-  host: process.env.BOTKIT_STORAGE_POSTGRES_HOST || 'localhost',
-  port: process.env.BOTKIT_STORAGE_POSTGRES_PORT || '5432'
+  // user: process.env.BOTKIT_STORAGE_POSTGRES_USER || 'botkit',
+  // database: process.env.BOTKIT_STORAGE_POSTGRES_DATABASE || 'botkit_test',
+  // password: process.env.BOTKIT_STORAGE_POSTGRES_PASSWORD || 'botkit',
+  // host: process.env.BOTKIT_STORAGE_POSTGRES_HOST || 'localhost',
+  // port: process.env.BOTKIT_STORAGE_POSTGRES_PORT || '5432'
+  postgresUri : process.env.postgresUri || 'postgres://botkit:botkit@localhost:5432/botkit_test'
 };
+
 const pgClient = new pg.Client(dbConfig);
 pgClient.connect();
 pgClient.query(`


### PR DESCRIPTION
Usage: 
```
var controller = Botkit.slackbot({
  storage: botkitStoragePostgres({
    postgresUri: 'postgres://botkit:botkit@localhost/botkit'
  })
});
```
Fix for issue #10 